### PR TITLE
Use global `isNaN()` instead of `Number.isNaN()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (str, pos) {
 	var size = str.length;
 	var i = pos ? Number(pos) : 0;
 
-	if (Number.isNaN(i)) {
+	if (isNaN(i)) {
 		i = 0;
 	}
 


### PR DESCRIPTION
The recent change of this package to use native `Number.isNaN()` instead of polyfill (#1) seems to break my build on Travis (https://github.com/hakatashi/mona-width/pull/3), because PhantomJS doesn't support `Number.isNaN()`.

It may also not work in Internet Explorer when browserified.

Since this module is polyfill (ponyfill?), the wider support is very desirable. As the input to this Number.isNaN seems to be [obviously Number](https://github.com/sindresorhus/code-point-at/blob/master/index.js#L11), we can simply replace it with global `isNaN()`.